### PR TITLE
Remove discard mount option on ramdisk

### DIFF
--- a/kill-ryzen.sh
+++ b/kill-ryzen.sh
@@ -17,7 +17,7 @@ if $USE_RAMDISK; then
   sudo modprobe zram num_devices=1 || exit 1
   echo 64G | sudo tee /sys/block/zram0/disksize || exit 1
   sudo mke2fs -q -m 0 -b 4096 -O sparse_super -L zram /dev/zram0 || exit 1
-  sudo mount -o relatime,nosuid,discard /dev/zram0 /mnt/ramdisk/ || exit 1
+  sudo mount -o relatime,nosuid /dev/zram0 /mnt/ramdisk/ || exit 1
   sudo mkdir -p /mnt/ramdisk/workdir || exit 1
   sudo chmod 777 /mnt/ramdisk/workdir || exit 1
   cp buildloop.sh /mnt/ramdisk/workdir/buildloop.sh || exit 1

--- a/save-ryzen.sh
+++ b/save-ryzen.sh
@@ -15,7 +15,7 @@ if $USE_RAMDISK; then
   sudo modprobe zram num_devices=1 || exit 1
   echo 64G | sudo tee /sys/block/zram0/disksize || exit 1
   sudo mke2fs -q -m 0 -b 4096 -O sparse_super -L zram /dev/zram0 || exit 1
-  sudo mount -o relatime,nosuid,discard /dev/zram0 /mnt/ramdisk/ || exit 1
+  sudo mount -o relatime,nosuid /dev/zram0 /mnt/ramdisk/ || exit 1
   sudo mkdir -p /mnt/ramdisk/workdir || exit 1
   sudo chmod 777 /mnt/ramdisk/workdir || exit 1
   cp buildloop.sh /mnt/ramdisk/workdir/buildloop.sh || exit 1


### PR DESCRIPTION
Discard should only be enabled for block devices that expose ATA_TRIM,
such as SSDs.  Ram disks don't and shouldn't expose ATA_TRIM, and don't
suffer from wear the same way SSDs do.

Closes suaefar/ryzen-test#11