### PR TITLE
Make ext4 filesystem explicitly on zram device

### DIFF
--- a/kill-ryzen.sh
+++ b/kill-ryzen.sh
@@ -16,7 +16,7 @@ if $USE_RAMDISK; then
   sudo mkdir -p /mnt/ramdisk || exit 1
   sudo modprobe zram num_devices=1 || exit 1
   echo 64G | sudo tee /sys/block/zram0/disksize || exit 1
-  sudo mke2fs -q -m 0 -b 4096 -O sparse_super -L zram /dev/zram0 || exit 1
+  sudo mkfs.ext4 -q -m 0 -b 4096 -O sparse_super -L zram /dev/zram0 || exit 1
   sudo mount -o relatime,nosuid,discard /dev/zram0 /mnt/ramdisk/ || exit 1
   sudo mkdir -p /mnt/ramdisk/workdir || exit 1
   sudo chmod 777 /mnt/ramdisk/workdir || exit 1

--- a/save-ryzen.sh
+++ b/save-ryzen.sh
@@ -14,7 +14,7 @@ if $USE_RAMDISK; then
   sudo mkdir -p /mnt/ramdisk || exit 1
   sudo modprobe zram num_devices=1 || exit 1
   echo 64G | sudo tee /sys/block/zram0/disksize || exit 1
-  sudo mke2fs -q -m 0 -b 4096 -O sparse_super -L zram /dev/zram0 || exit 1
+  sudo mkfs.ext4 -q -m 0 -b 4096 -O sparse_super -L zram /dev/zram0 || exit 1
   sudo mount -o relatime,nosuid,discard /dev/zram0 /mnt/ramdisk/ || exit 1
   sudo mkdir -p /mnt/ramdisk/workdir || exit 1
   sudo chmod 777 /mnt/ramdisk/workdir || exit 1


### PR DESCRIPTION
The command 'mke2fs' can have different results depending on the
configuration of /etc/mke2fs.conf.  If an ext2 or ext3 filesystem is
created, mount with "-o discard" will fail.

Use standard mkfs.ext4 command available on all distributions to
eliminate potential variation in resulting filesystem.

Per Arch's wiki, ext4 supports continuous fstrim while ext3 does not:
https://wiki.archlinux.org/index.php/Solid_State_Drives#TRIM

Closes suaefar/ryzen-test#11