### PR TITLE
added gcc8.1 for Arch & Ryzen 2000 series

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Script to reproduce randomly crashing processes under load on AMD Ryzen processo
 # Try it
 Run
 
-> ./kill-ryzen.sh
+```
+./kill-ryzen.sh
+```
 
 and watch the output.
 
@@ -36,12 +38,16 @@ Alternatively, smaller software packages could be tried (suggestions welcome).
 
 You can also try to run fewer loops but allow them to use more threads, e.g., 8 loops with 2 threads each.
 
-> ./kill-ryzen.sh 8 2
+```
+./kill-ryzen.sh 8 2
+```
 
 However, with only 16Gb RAM, this configuration might still run out of memory.
 4 loops with 4 threads each is a safe choice on machines with 16Gb RAM.
 
-> ./kill-ryzen.sh 4 4
+```
+/kill-ryzen.sh 4 4
+```
 
 # Update on my experience (suaefar)
 I wrote this script to reproducibly show that there was a severe problem with my early (adopted) Ryzen processor.
@@ -59,3 +65,14 @@ I have not experienced a single segfault until now (2017-10-31).
 [2] https://github.com/HoerTech-gGmbH/openMHA
 
 [3] https://community.amd.com/thread/215773
+
+
+# Small update for Arch Linux / Ryzen 2000 series CPUs (daniel451)
+Ubuntu 17.04 is discontinued and Ryzen 2000 series CPUs do not seem to work without adjustments. Same goes for Arch Linux. I have simply substituted gcc7.1 with gcc8.1 and manual dependency installation. This way the script can be run with gcc8.1. Unless Ubuntu 17.04 is not working for you it is *not* recommended to use the updated version for the sake of reproducibility.
+
+To run the updated version:
+
+```
+cd arch-linux
+./kill-ryzen.sh
+```

--- a/arch-linux/buildloop.sh
+++ b/arch-linux/buildloop.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+function error() {
+  echo $(date)" ${1} failed"
+  exit 1
+}
+
+NAME="$1"
+TPROC="$2"
+CDIR="$PWD"
+WDIR="${CDIR}/buildloop.d/${NAME}/"
+for ((I=0;1;I++)); do
+  cd "${CDIR}" || error "leave workdir"
+  echo $(date)" start ${I}"
+  [ -e "${WDIR}" ] && rm -rf "${WDIR}"
+  mkdir -p "${WDIR}" || error "create workdir"
+  cd "${WDIR}" || error "change to workdir"
+  ${CDIR}/gcc-8.1.0/configure --disable-multilib &> configure.log || error "configure"
+  make -j "$TPROC" &> build.log || error "build"
+done

--- a/arch-linux/kill-ryzen.sh
+++ b/arch-linux/kill-ryzen.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+export LANG=C
+
+USE_RAMDISK=true
+CLEAN_ON_EXIT=false
+NPROC=$1
+TPROC=$2
+
+[ -n "$NPROC" ] || NPROC=$(nproc)
+[ -n "$TPROC" ] || TPROC=1
+
+cleanup() {
+  sudo rm -rf /mnt/ramdisk/*
+  sudo umount /mnt/ramdisk
+}
+if $CLEAN_ON_EXIT; then
+  trap "cleanup" SIGHUP SIGINT SIGTERM EXIT
+fi
+
+# ARCH LINUX -> please install missing requirements yourself
+
+#echo "Install required packages"
+#if which apt-get &>/dev/null; then
+ #sudo apt-get install build-essential
+#elif which dnf &>/dev/null; then
+ #sudo dnf install -y @development-tools
+#else
+ #exit 1
+#fi
+
+if $USE_RAMDISK; then
+  echo "Create compressed ramdisk"
+  sudo mkdir -p /mnt/ramdisk || exit 1
+  sudo modprobe zram num_devices=1 || exit 1
+  echo 64G | sudo tee /sys/block/zram0/disksize || exit 1
+  sudo mkfs.ext4 -q -m 0 -b 4096 -O sparse_super -L zram /dev/zram0 || exit 1
+  sudo mount -o relatime,nosuid,discard /dev/zram0 /mnt/ramdisk/ || exit 1
+  sudo mkdir -p /mnt/ramdisk/workdir || exit 1
+  sudo chmod 777 /mnt/ramdisk/workdir || exit 1
+  cp buildloop.sh /mnt/ramdisk/workdir/buildloop.sh || exit 1
+  cd /mnt/ramdisk/workdir || exit 1
+  mkdir tmpdir || exit 1
+  export TMPDIR="$PWD/tmpdir"
+fi
+
+echo "Download GCC sources"
+#wget ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-7.1.0/gcc-7.1.0.tar.bz2 || exit 1
+wget ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-8.1.0/gcc-8.1.0.tar.gz || exit 1
+
+echo "Extract GCC sources"
+tar xfz gcc-8.1.0.tar.gz || exit 1
+
+echo "Download prerequisites"
+(cd gcc-8.1.0/ && ./contrib/download_prerequisites)
+
+[ -d 'buildloop.d' ] && rm -r 'buildloop.d'
+mkdir -p buildloop.d || exit 1
+
+echo "cat /proc/cpuinfo | grep -i -E \"(model name|microcode)\""
+cat /proc/cpuinfo | grep -i -E "(model name|microcode)"
+echo "sudo dmidecode -t memory | grep -i -E \"(rank|speed|part)\" | grep -v -i unknown"
+sudo dmidecode -t memory | grep -i -E "(rank|speed|part)" | grep -v -i unknown
+echo "uname -a"
+uname -a
+echo "cat /proc/sys/kernel/randomize_va_space"
+cat /proc/sys/kernel/randomize_va_space
+
+# start journal process in different working directory
+pushd /
+  journalctl -kf | sed 's/^/[KERN] /' &
+popd
+echo "Using ${NPROC} parallel processes"
+
+START=$(date +%s)
+for ((I=0;$I<$NPROC;I++)); do
+  (./buildloop.sh "loop-$I" "$TPROC" || echo "TIME TO FAIL: $(($(date +%s)-${START})) s") | sed "s/^/\[loop-${I}\] /" &
+  sleep 1
+done
+
+wait


### PR DESCRIPTION
I have added an *arch-linux* directory, putting updated copies of ``kill-ryzen.sh`` and ``buildloop.sh`` for gcc8.1 there. This worked for me with Ryzen 7 2700X and Arch Linux as well as Ubuntu 18.04 LTS.

+ minor updated for readme